### PR TITLE
Arguments passed/retrieved to/from LunaService must be stringify/parsed

### DIFF
--- a/qml/LaunchBar/LaunchableAppIcon.qml
+++ b/qml/LaunchBar/LaunchableAppIcon.qml
@@ -26,7 +26,7 @@ Column {
 
         MouseArea {
             anchors.fill: parent
-            onClicked: launchableAppIcon.lunaNextLS2Service.call("luna://com.palm.applicationManager/launch", {"id": launchableAppIcon.appId}, undefined, handleError)
+            onClicked: launchableAppIcon.lunaNextLS2Service.call("luna://com.palm.applicationManager/launch", JSON.stringify({"id": launchableAppIcon.appId}), undefined, handleError)
 
             function handleError(message) {
                 console.log("Could not start application " + launchableAppIcon.appId + " : " + message);

--- a/qml/LunaSysAPI/ApplicationModel.qml
+++ b/qml/LunaSysAPI/ApplicationModel.qml
@@ -17,10 +17,11 @@ ListModel {
     }
 
     function refresh() {
-        lunaNextLS2Service.call("luna://com.palm.applicationManager/listApps", {"filter": filter}, fillFromJSONResult, handleError);
+        lunaNextLS2Service.call("luna://com.palm.applicationManager/listApps", JSON.stringify({"filter": filter}), fillFromJSONResult, handleError);
     }
 
-    function fillFromJSONResult(result) {
+    function fillFromJSONResult(data) {
+        var result = JSON.parse(data);
         applicationModel.clear();
         if(result.returnValue && result.apps !== undefined) {
             for(var i=0; i<result.apps.length; i++) {

--- a/qml/Tests/imports/LunaNext/LunaService.qml
+++ b/qml/Tests/imports/LunaNext/LunaService.qml
@@ -6,11 +6,12 @@ QtObject {
     property bool usePrivateBus: false
 
     function call(serviceURI, jsonArgs, returnFct, handleError) {
+        var args = JSON.parse(jsonArgs);
         if( serviceURI === "luna://com.palm.applicationManager/listApps" ) {
-            listApps_call(jsonArgs, returnFct, handleError);
+            listApps_call(args, returnFct, handleError);
         }
         else if( serviceURI === "luna://com.palm.applicationManager/launch" ) {
-            launchApp_call(jsonArgs, returnFct, handleError);
+            launchApp_call(args, returnFct, handleError);
         }
 
         else {
@@ -19,13 +20,13 @@ QtObject {
     }
 
     function listApps_call(jsonArgs, returnFct, handleError) {
-        returnFct({"returnValue": true,
+        returnFct(JSON.stringify({"returnValue": true,
                     "apps": [
              { "title": "Calendar", "id": "com.palm.calendar", "icon": "/usr/share/icons/hicolor/32x32/apps/gnome-panel-clock.png" },
              { "title": "Email", "id": "com.palm.email", "icon": "/usr/share/icons/hicolor/32x32/apps/gnome-panel-clock.png" },
              { "title": "Calculator", "id": "com.palm.calc", "icon": "/usr/share/icons/hicolor/32x32/apps/gnome-panel-clock.png", "showInSearch": false },
              { "title": "Snowshoe", "id": "snowshoe", "icon": "/usr/share/icons/hicolor/32x32/apps/gnome-panel-clock.png" }
-           ]});
+           ]}));
     }
 
     function launchApp_call(jsonArgs, returnFct, handleError) {


### PR DESCRIPTION
Due to the internal implementation of the LunaService component it's currently required to
stringify/parse the JSON arguments when calling a service method or retrieving a response.

Signed-off-by: Simon Busch morphis@gravedo.de
