### PR TITLE
SlidingItemArea: fix to have the MouseArea in front of the slided item.

### DIFF
--- a/qml/CardView/SlidingItemArea.qml
+++ b/qml/CardView/SlidingItemArea.qml
@@ -62,6 +62,8 @@ Item {
         drag.filterChildren: filterChildren
         enabled: slidingEnabled
 
+        z: slidingTargetItem.z + 1
+
         onClicked: {
             sliderClicked();
         }


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
