### PR TITLE
Resize client windows to have the right size

### DIFF
--- a/qml/WindowManager/WindowManager.qml
+++ b/qml/WindowManager/WindowManager.qml
@@ -12,6 +12,9 @@ Item {
 
     property Item currentActiveWindowWrapper
 
+    property real defaultWindowWidth: Settings.displayWidth
+    property real defaultWindowHeight: Settings.displayHeight
+
     property real cornerRadius: 20
 
     signal requestPreviousState(Item windowWrapper)

--- a/qml/WindowManager/WindowWrapper.qml
+++ b/qml/WindowManager/WindowWrapper.qml
@@ -35,7 +35,13 @@ Item {
             window.parent = childWrapper;
             childWrapper.wrappedChild = window;
             childWrapper.children = [ window ];
+
+            /* This resizes only the quick item which contains the child surface but
+             * doesn't really resize the client window */
             window.anchors.fill = childWrapper;
+
+            /* Resize the real client window to have the right size */
+            window.changeSize(Qt.size(windowManager.defaultWindowWidth, windowManager.defaultWindowHeight));
         }
 
         function postEvent(event) {

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -77,6 +77,9 @@ Compositor {
 
         anchors.fill: parent
 
+        defaultWindowWidth: Settings.displayWidth
+        defaultWindowHeight: Settings.displayHeight - statusBarInstance.height - gestureAreaInstance.height
+
         dashboardInstance: dashboardInstance
         statusBarInstance: statusBarInstance
         gestureAreaInstance: gestureAreaInstance


### PR DESCRIPTION
Client windows should only take the place between the status bar and the gesture area not
never using another window size.

Signed-off-by: Simon Busch morphis@gravedo.de
