### PR TITLE
Rework application model to use correct API of the application manager

### DIFF
--- a/qml/LunaSysAPI/ApplicationModel.qml
+++ b/qml/LunaSysAPI/ApplicationModel.qml
@@ -6,7 +6,7 @@ ListModel {
 
     property string filter: "*"
     property QtObject lunaNextLS2Service: LunaService {
-        id: lunaNextLS2Service
+        id: service
         name: "org.webosports.luna"
         usePrivateBus: true
     }
@@ -17,22 +17,50 @@ ListModel {
     }
 
     function refresh() {
-        lunaNextLS2Service.call("luna://com.palm.applicationManager/listApps", JSON.stringify({"filter": filter}), fillFromJSONResult, handleError);
+        service.call("luna://com.palm.applicationManager/listLaunchPoints",
+            "{}", fillFromJSONResult, handleError);
     }
 
     function fillFromJSONResult(data) {
         var result = JSON.parse(data);
         applicationModel.clear();
-        if(result.returnValue && result.apps !== undefined) {
-            for(var i=0; i<result.apps.length; i++) {
-                applicationModel.append(result.apps[i]);
+        if(result.returnValue && result.launchPoints !== undefined) {
+            for(var i=0; i<result.launchPoints.length; i++) {
+                applicationModel.append(result.launchPoints[i]);
             }
         }
+    }
+
+    function handleLaunchPointChanges(data) {
+        var response = JSON.parse(data);
+
+        // skip the initial subscription confirmation
+        if (response.subscribed !== undefined)
+            return;
+
+        refresh();
+    }
+
+    function handleApplicationManagerStatusChanged(data) {
+        var response = JSON.parse(data);
+
+        if (!response.connected)
+            return;
+
+        // register handler for possible launch point change events
+        service.subscribe("luna://com.palm.applicationManager/launchPointChanges",
+            JSON.stringify({"subscribe":true}), handleLaunchPointChanges, handleError);
+
+        refresh();
     }
 
     function handleError(errorMessage) {
         console.log("Failed to call application manager: " + errorMessage);
     }
 
-    Component.onCompleted: refresh();
+    Component.onCompleted: {
+        service.subscribe("luna://com.palm.bus/signal/registerServerStatus",
+            JSON.stringify({"serviceName":"com.palm.applicationManager"}),
+            handleApplicationManagerStatusChanged, handleError);
+    }
 }


### PR DESCRIPTION
The application model now gets automatically updated once a launch point within the
application manager is removed, added or changed. Furthermore this includes now handling
of all different launch point types which can be also a link to a website. Applications
which should be hidden from the launcher like the first use application are now correctly
hidden as they are not having a launch point.

Signed-off-by: Simon Busch morphis@gravedo.de
