### PR TITLE
If app doesn't have an app id display always the default app menu text

### DIFF
--- a/qml/StatusBar/AppMenu.qml
+++ b/qml/StatusBar/AppMenu.qml
@@ -56,23 +56,29 @@ Item {
         }
     }
 
+    function setDefaultAppMenuTitle() {
+        title.text = defaultAppMenuTitle;
+    }
+
     function handleGetAppInfoResponse(message) {
         var response = JSON.parse(message.payload);
         if (response.returnValue && response.appInfo && response.appInfo.appmenu)
             title.text = response.appInfo.appmenu;
         else
-            title.text = defaultAppMenuTitle;
+            setDefaultAppMenuTitle()
     }
 
     function handleGetAppInfoError(error) {
         console.log("Could not retrieve information about current application: " + error);
-        title.text = defaultAppMenuTitle;
+        setDefaultAppMenuTitle();
     }
 
     function updateAfterAppChange() {
         var activeWindowAppId = determineActiveWindowAppId();
-        if (activeWindowAppId.length === 0)
+        if (activeWindowAppId.length === 0) {
+            setDefaultAppMenuTitle();
             return;
+        }
         service.call("palm://com.palm.applicationManager/getAppInfo",
                      JSON.stringify({"appId":activeWindowAppId}),
                      handleGetAppInfoResponse, handleGetAppInfoError);


### PR DESCRIPTION
Fixes bug #489

Signed-off-by: Simon Busch morphis@gravedo.de
