### PR TITLE
Implement performance overlay support

### DIFF
--- a/qml/CardShell.qml
+++ b/qml/CardShell.qml
@@ -35,32 +35,6 @@ Rectangle {
 
     color: "black"
 
-    Loader {
-        anchors.top: root.top
-        anchors.left: root.left
-
-        width: 50
-        height: 32
-
-        // always on top of everything else!
-        z: 1000
-
-        Component {
-            id: fpsTextComponent
-            Text {
-                color: "red"
-                font.pixelSize: FontUtils.sizeToPixels("medium")
-                text: fpsCounter.fps + " fps"
-
-                FpsCounter {
-                    id: fpsCounter
-                }
-            }
-        }
-
-        sourceComponent: Settings.displayFps ? fpsTextComponent : null;
-    }
-
     Preferences {
         id: preferences
     }

--- a/qml/CardsArea.qml
+++ b/qml/CardsArea.qml
@@ -20,6 +20,7 @@ import QtQuick 2.0
 import LunaNext.Common 0.1
 import LunaNext.Shell 0.1
 import LunaNext.Compositor 0.1
+import LunaNext.Performance 0.1
 
 import "CardView"
 import "StatusBar"
@@ -55,6 +56,45 @@ WindowManager {
         if( compositor )
             compositor.clearKeyboardFocus();
     }
+
+    Loader {
+        anchors.top: root.top
+        anchors.left: root.left
+
+        width: 50
+        height: 32
+
+        // always on top of everything else!
+        z: 1000
+
+        Component {
+            id: fpsTextComponent
+            Text {
+                color: "red"
+                font.pixelSize: FontUtils.sizeToPixels("medium")
+                text: fpsCounter.fps + " fps"
+
+                FpsCounter {
+                    id: fpsCounter
+                }
+            }
+        }
+
+        sourceComponent: systemService.fpsVisible ? fpsTextComponent : null;
+    }
+
+    /* Component already uses an Loader internally so need to do that again here */
+    PerformanceOverlay {
+        z: 1000
+        active: systemService.performanceUIVisible
+
+        onActiveChanged: {
+            /* User can disable performance UI by clicking on it */
+            if (active !== systemService.performanceUIVisible)
+                systemService.performanceUIVisible = active;
+        }
+    }
+
 
     Item {
         id: background

--- a/qml/Tests/imports/LunaNext/Performance/LunaNext.Performance.qmltypes
+++ b/qml/Tests/imports/LunaNext/Performance/LunaNext.Performance.qmltypes
@@ -1,0 +1,7 @@
+import QtQuick.tooling 1.1
+
+// This file describes the plugin-supplied types contained in the library.
+// It is used for QML tooling purposes only.
+
+Module {
+}

--- a/qml/Tests/imports/LunaNext/Performance/PerformanceOverlay.qml
+++ b/qml/Tests/imports/LunaNext/Performance/PerformanceOverlay.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.1
+
+Item {
+    property bool active: false
+}

--- a/qml/Tests/imports/LunaNext/Performance/qmldir
+++ b/qml/Tests/imports/LunaNext/Performance/qmldir
@@ -1,0 +1,6 @@
+module LunaNext.Performance
+PerformanceOverlay 0.1 PerformanceOverlay.qml
+
+typeinfo LunaNext.Performance.qmltypes
+
+typeinfo LunaNext.Performance.qmltypes


### PR DESCRIPTION
- performance overlay and fps counter are now configurable over ls2 again so we can
  disable/enable them from the settings app
- states are stored only per session and not accross restarts

Signed-off-by: Simon Busch morphis@gravedo.de
