### PR TITLE
Fix binding issue with performance overlay

### DIFF
--- a/qml/CardsArea.qml
+++ b/qml/CardsArea.qml
@@ -85,9 +85,9 @@ WindowManager {
 
     /* Component already uses an Loader internally so need to do that again here */
     PerformanceOverlay {
+        id: performanceOverlay
         z: 1000
-        active: systemService.performanceUIVisible
-
+        active: false
         onActiveChanged: {
             /* User can disable performance UI by clicking on it */
             if (active !== systemService.performanceUIVisible)
@@ -135,6 +135,10 @@ WindowManager {
         screenShooter: screenShooter
         cardViewInstance: cardViewInstance
         compositorInstance: compositor
+
+        onPerformanceUIVisibleChanged: {
+            performanceOverlay.active = performanceUIVisible;
+        }
     }
 
     NotificationService {


### PR DESCRIPTION
- when user disables the overlay by clicking on it there the binding as it is implemented
  doesn't work and the values from the overlay and the service will be out of sync causing
  us not being able to activate the overlay again.

Signed-off-by: Simon Busch morphis@gravedo.de
