### PR TITLE
set height and width of inversemousearea to match flickablearea.

### DIFF
--- a/qml/StatusBar/SystemMenu/SystemMenu.qml
+++ b/qml/StatusBar/SystemMenu/SystemMenu.qml
@@ -363,7 +363,8 @@ Item {
     }
 
     InverseMouseArea {
-        anchors.fill: parent
+        width: mainMenu.width;
+        height: Math.min(systemMenu.height - clipRect.anchors.topMargin - clipRect.anchors.bottomMargin, mainMenu.height);
         sensingArea: root
         onClicked: {
             resetMenu()


### PR DESCRIPTION
resolves issue #733 http://issues.webos-ports.org/issues/733
