### PR TITLE
Don't resubscribe when telephony service reports noservice

### DIFF
--- a/qml/StatusBar/StatusBar.qml
+++ b/qml/StatusBar/StatusBar.qml
@@ -57,10 +57,7 @@ Item {
             return;
         }
         else if(response.extended.state==="noservice")
-        {
-            resubscribeTimer.start();
             return;
-        }
         else if (response.extended.registration && response.extended.state !== "noservice") {
             carrierName = response.extended.networkName
             carrierText.text = carrierName


### PR DESCRIPTION
Resubscribing here triggers an indefinite loop and is not necessary.

Signed-off-by: Simon Busch <morphis@gravedo.de>