### PR TITLE
LockMode: Prevent the lock pad to be shown in DockMode state

### DIFF
--- a/qml/LockScreen/LockScreen.qml
+++ b/qml/LockScreen/LockScreen.qml
@@ -66,7 +66,7 @@ Item {
 
             if (response.lockState === "locked")
                 lockScreen.state = "pad";
-            else if (response.lockState === "unlocked")
+            else if (response.lockState === "unlocked" || response.lockState === "dockmode")
                 lockScreen.state = "none";
         }
 


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>