### PR TITLE
Where possible use miniIcon instead of appIcon (for banner)

### DIFF
--- a/qml/Notifications/NotificationArea.qml
+++ b/qml/Notifications/NotificationArea.qml
@@ -92,7 +92,7 @@ Rectangle {
             mergedModel.append({"notifType": "dashboard",
                                 "window": window,
                                 "notifObject": {},
-                                "iconUrl": window.appIcon,
+                                "iconUrl": window.miniIcon ? window.miniIcon : window.appIcon,
                                 "notifHeight": dashHeight});
         }
         onRowsAboutToBeRemoved: {


### PR DESCRIPTION
So we have the correct icon for banners. We should use the simplest version (miniIcon) where possible.