### PR TITLE
Fix power key handling

### DIFF
--- a/qml/LaunchBar/JustTypeField.qml
+++ b/qml/LaunchBar/JustTypeField.qml
@@ -134,7 +134,7 @@ Item {
          * between 0x00 and 0xff.
         */
 
-        if( key <= 0x0ff )
+        if( key <= 0x0ff && key >=0x02)
             return true;
         return false;
     }


### PR DESCRIPTION
Power key started to misbehave after QT 5.6 upgrade and would show Just
Type. This will fix it.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>