### PR TITLE
CardGroupListView: update Keys.forwardTo manually

### DIFF
--- a/qml/CardView/CardGroupListView.qml
+++ b/qml/CardView/CardGroupListView.qml
@@ -157,7 +157,6 @@ Item {
         }
 
         Keys.onPressed: {
-            updateKeysForwardTo();
             if (cardView.state === "cardList") {
                 if (event.key === Qt.Key_Left) {
                     event.accepted = true;
@@ -394,6 +393,7 @@ Item {
         if( foundGroupIndex>=0 ) {
             internalListView.setCurrentCardIndex(foundGroupIndex);
         }
+        updateKeysForwardTo();
     }
 
     function updateKeysForwardTo() {

--- a/qml/CardView/CardGroupListView.qml
+++ b/qml/CardView/CardGroupListView.qml
@@ -45,7 +45,7 @@ Item {
     signal cardDragStart(Item window);
 
     focus: true
-    Keys.forwardTo: [internalListView, currentActiveWindow()]
+    Component.onCompleted: updateKeysForwardTo()
 
     Connections {
         target: AppTweaks
@@ -157,6 +157,7 @@ Item {
         }
 
         Keys.onPressed: {
+            updateKeysForwardTo();
             if (cardView.state === "cardList") {
                 if (event.key === Qt.Key_Left) {
                     event.accepted = true;
@@ -393,6 +394,10 @@ Item {
         if( foundGroupIndex>=0 ) {
             internalListView.setCurrentCardIndex(foundGroupIndex);
         }
+    }
+
+    function updateKeysForwardTo() {
+        Keys.forwardTo = [internalListView, currentActiveWindow()];
     }
 }
 


### PR DESCRIPTION
usage of functions seems stopped to work for some reason.
Bug #1127.
Signed-off-by: Nikolay Nizov <nizovn@gmail.com>