### PR TITLE
Notifications: don't resize the client window too soon

### DIFF
--- a/qml/Notifications/AlertWindowsArea.qml
+++ b/qml/Notifications/AlertWindowsArea.qml
@@ -48,7 +48,7 @@ Rectangle {
             height: window ? window.height : 0
             onHeightChanged: computeNewRootHeight();
 
-            onWidthChanged: if(window) window.changeSize(Qt.size(alertItem.width, alertItem.height));
+            onWidthChanged: if(window && window.height>0) window.changeSize(Qt.size(alertItem.width, alertItem.height));
 
             children: [ window ]
 


### PR DESCRIPTION
If we call ChangeSize(alertItem.width, window.height) when the window's
height hasn't been updated yet, we will end up with a window of
height zero.
Anyway if window.height <= 0, then onHeightChanged *will* be called
later on, and ChangeSize will actually be applied at that time.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>