### PR TITLE
Fix launchParams to be empty to maintain legacy compatibility

### DIFF
--- a/qml/LaunchBar/FullLauncher.qml
+++ b/qml/LaunchBar/FullLauncher.qml
@@ -351,7 +351,7 @@ Item {
                     modelTitle: model.title
                     modelIcon: model.icon
                     modelId: model.id
-                    modelParams:  (typeof model.params === "undefined") ? "{}" : model.params
+                    modelParams:  (typeof model.params === "undefined") ? "" : model.params
                     modelIndex: index
                     modelRemovable: !!model.removable
                     modelHideable: false

--- a/qml/LaunchBar/LaunchableAppIcon.qml
+++ b/qml/LaunchBar/LaunchableAppIcon.qml
@@ -26,7 +26,7 @@ Item {
     property string appIcon
     property string appTitle
     property string appId
-    property string appParams: "{}"
+    property string appParams: ""
     property bool showTitle: false
 
     property real iconSize: 64


### PR DESCRIPTION
Having {} instead of an empty string would cause weird issues for Enyo 1
app.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>