### PR TITLE
CardView: update Keys.forwardTo on window close

### DIFF
--- a/qml/CardView/CardGroupListView.qml
+++ b/qml/CardView/CardGroupListView.qml
@@ -75,6 +75,7 @@ Item {
                     internalListView.delayedCardSelect(newWindow);
                 }
             }
+            onCardRemoved: updateKeysForwardTo(false);
         }
 
         delegate: CardGroupDelegate {

--- a/qml/CardView/CardGroupModel.qml
+++ b/qml/CardView/CardGroupModel.qml
@@ -13,6 +13,7 @@ ListModel {
     id: listCardGroupsModel
 
     signal newCardInserted(int group, int index, Item newWindow)
+    signal cardRemoved()
 
     property WindowModel listCardsModel: WindowModel {
         windowTypeFilter: WindowType.Card
@@ -129,6 +130,7 @@ ListModel {
                         // select the previous one
                         listCardGroupsModel.setCurrentCardInGroup(listCardGroupsModel.get(groupIndex), Math.max(currentCardInGroup-1,0));
                     }
+                    cardRemoved();
                     windowList.remove(windowIndex);
 
                     // If the group is now empty, remove it


### PR DESCRIPTION
Fixes crash when window closes itself.
Steps to reproduce crash: open fingerterm, type exit, open launcher and
press esc twice.

Signed-off-by: Nikolay Nizov <nizovn@gmail.com>