### PR TITLE
Fix filename for ringtone and add assets path to search

### DIFF
--- a/qml/LunaSysAPI/Preferences.qml
+++ b/qml/LunaSysAPI/Preferences.qml
@@ -30,7 +30,7 @@ Item {
 
     property string wallpaperFile: ""
     readonly property int rotationInvalid: 400
-    property string ringtoneFullPath: "/usr/palm/sounds/ringtone.wav"
+    property string ringtoneFullPath: "/usr/palm/sounds/ringtone.mp3"
     property string alerttoneFullPath: "/usr/palm/sounds/alert.wav"
     property string notificationtoneFullPath: "/usr/palm/sounds/notification.wav"
     property string locale: "en_us"

--- a/qml/Notifications/BannerPopupArea.qml
+++ b/qml/Notifications/BannerPopupArea.qml
@@ -131,8 +131,14 @@ Item {
                 var basePath = response.basePath;
                 var appFolder = basePath.match(/(.*)[\/\\]/)[1]||'';
 
-
+                // Try the locale in the resources folder used by both Enyo 1 and 2.
                 basePathRoot = appFolder + "/resources/" + preferences.locale + "/" + entry;
+                if (FileUtils.exists(basePathRoot)){
+                    return basePathRoot;
+                }
+
+                // Try in the Enyo 2 assets folder path
+                basePathRoot = appFolder + "/assets/" + entry;
                 if (FileUtils.exists(basePathRoot)){
                     return basePathRoot;
                 }
@@ -143,9 +149,7 @@ Item {
                     return basePathRoot;
                 }
             }
-
         }
-
 
         function handleGetAppInfoError(error) {
             console.log("Could not retrieve information about current application: " + error);


### PR DESCRIPTION
-Ringtone filename should have mp3 extension instead of wav.
-Enyo 2 apps use assets folder, so add these to the paths to search.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>