### PR TITLE
Launcher: don't take action on tap gesture

### DIFF
--- a/qml/LaunchBar/Launcher.qml
+++ b/qml/LaunchBar/Launcher.qml
@@ -205,9 +205,6 @@ Item {
     Connections {
         id: gestureAreaConnections
         target: gestureAreaInstance
-        onTapGesture: {
-            state = "launchbar";
-        }
         onSwipeUpGesture:{
             if( state === "launchbar" ) {
                 state = "fullLauncher";


### PR DESCRIPTION
Let the cardview change the global window state, the Launcher
will then be put in the correct state as a consequence.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>