### PR TITLE
LaunchBar: Let Phone app depend on Settings.tabletUi instead & arrange icons.

### DIFF
--- a/qml/LaunchBar/LaunchBar.qml
+++ b/qml/LaunchBar/LaunchBar.qml
@@ -235,32 +235,6 @@ Item {
         console.log("Could not fulfill DB operation : " + message)
     }
 
-    function __getAppManager(action, params, handleResultAM) {
-        lunaNextLS2Service.call("luna://com.palm.applicationManager/" + action, JSON.stringify(params),
-                   handleResultAM, __handleAppMgrError)
-    }
-
-    function __phoneAppStatusResult(message) {
-        var result = JSON.parse(message.payload)
-        //In case returnvalue is true, phone app is installed, otherwise we use the browser instead
-        if(result.returnValue)
-        {
-            launcherListModel.model.append({appId: "org.webosports.app.phone",   icon: "/usr/palm/applications/org.webosports.app.phone/icon.png"});
-        }
-        else
-        {
-            launcherListModel.model.append({appId: "org.webosports.app.browser",   icon: "/usr/palm/applications/org.webosports.app.browser/icon.png"});
-        }
-        launcherListModel.model.append({appId: "com.palm.app.email",         icon: "/usr/palm/applications/com.palm.app.email/icon.png"});
-        launcherListModel.model.append({appId: "org.webosinternals.preware", icon: "/usr/palm/applications/org.webosinternals.preware/icon.png"});
-        launcherListModel.model.append({appId: "org.webosports.app.memos",   icon: "/usr/palm/applications/org.webosports.app.memos/icon.png"});
-    }
-
-    function __handleAppMgrError(message) {
-        console.log("Unable to query Application Manager, error message is: "+JSON.stringify(message.payload))
-    }
-
-
     function __queryDB(action, params, handleResultFct) {
         lunaNextLS2Service.call("luna://com.palm.db/" + action, JSON.stringify(params),
                   handleResultFct, __handleDBError)
@@ -277,8 +251,18 @@ Item {
         }
         else {
             //fallback to static filling
-            //First icon is depending on availability of phone app, which we check and we'll populate the list accordingly
-            __getAppManager("getAppInfo", {appId: "org.webosports.app.phone"},__phoneAppStatusResult);
+            //First icon is depending on Settings.tabletUi, which we check and we'll populate the list accordingly
+            if(Settings.tabletUi)
+            {
+                launcherListModel.model.append({appId: "org.webosports.app.browser",   icon: "/usr/palm/applications/org.webosports.app.browser/icon.png"});
+            }
+            else
+            {
+                launcherListModel.model.append({appId: "org.webosports.app.phone",   icon: "/usr/palm/applications/org.webosports.app.phone/icon.png"});
+            }
+            launcherListModel.model.append({appId: "com.palm.app.email",         icon: "/usr/palm/applications/com.palm.app.email/icon.png"});
+            launcherListModel.model.append({appId: "org.webosinternals.preware", icon: "/usr/palm/applications/org.webosinternals.preware/icon.png"});
+            launcherListModel.model.append({appId: "org.webosports.app.memos",   icon: "/usr/palm/applications/org.webosports.app.memos/icon.png"});
 
         }
     }

--- a/qml/LaunchBar/LaunchBar.qml
+++ b/qml/LaunchBar/LaunchBar.qml
@@ -255,15 +255,18 @@ Item {
             if(Settings.tabletUi)
             {
                 launcherListModel.model.append({appId: "org.webosports.app.browser",   icon: "/usr/palm/applications/org.webosports.app.browser/icon.png"});
+                launcherListModel.model.append({appId: "com.palm.app.email",         icon: "/usr/palm/applications/com.palm.app.email/icon.png"});
+                launcherListModel.model.append({appId: "com.palm.app.calendar", icon: "/usr/palm/applications/com.palm.app.calendar/images/icon-256x256.png"});
+                launcherListModel.model.append({appId: "org.webosports.app.messaging", icon: "/usr/palm/applications/org.webosports.app.messaging/icon.png"});
+                launcherListModel.model.append({appId: "org.webosports.app.memos",   icon: "/usr/palm/applications/org.webosports.app.memos/icon.png"});
             }
             else
             {
                 launcherListModel.model.append({appId: "org.webosports.app.phone",   icon: "/usr/palm/applications/org.webosports.app.phone/icon.png"});
+                launcherListModel.model.append({appId: "org.webosports.app.messaging", icon: "/usr/palm/applications/org.webosports.app.messaging/icon.png"});
+                launcherListModel.model.append({appId: "com.palm.app.email",         icon: "/usr/palm/applications/com.palm.app.email/icon.png"});
+                launcherListModel.model.append({appId: "com.palm.app.calendar", icon: "/usr/palm/applications/com.palm.app.calendar/images/icon-256x256.png"});
             }
-            launcherListModel.model.append({appId: "com.palm.app.email",         icon: "/usr/palm/applications/com.palm.app.email/icon.png"});
-            launcherListModel.model.append({appId: "org.webosinternals.preware", icon: "/usr/palm/applications/org.webosinternals.preware/icon.png"});
-            launcherListModel.model.append({appId: "org.webosports.app.memos",   icon: "/usr/palm/applications/org.webosports.app.memos/icon.png"});
-
         }
     }
     function saveCurrentLayout() {


### PR DESCRIPTION
Since we now provide the Phone app on all targets, we need to make sure
we deal with it properly. It seems that Settings.tabletUi is the best
solution for now.

Have the icons like legacy for now.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>