### PR TITLE
LaunchBar.qml: Don't use asc: true since it's invalid

### DIFF
--- a/qml/LaunchBar/LaunchBar.qml
+++ b/qml/LaunchBar/LaunchBar.qml
@@ -335,7 +335,7 @@ Item {
         // appId: string
         if( !Settings.isTestEnvironment ) {
             __queryDB("find",
-                      {query:{from:"org.webosports.lunalauncher:1", orderBy: "pos", asc: true, limit:5}},
+                      {query:{from:"org.webosports.lunalauncher:1", orderBy: "pos", limit:5}},
                       __quickLaunchBarDBResult);
         }
         launcherRow.visible = true;


### PR DESCRIPTION
Fixes: Oct 26 11:38:22 qemux86 mojodb-luna[569]: [] [pmlog] DB8 MOJ_SERVICE_WARNING {"sender":"org.webosports.luna","method":"find","payload":{"query":{"asc":true,"from":"org.webosports.lunalauncher:1","limit":5,"orderBy":"pos"}},"error":"invalid parameters: caller='org.webosports.luna' error='property not allowed - 'asc' for property 'query''","reqErr":22}

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>