### PR TITLE
Bluetooth: Switch from org.nemomobile.dbus to Nemo.DBus

### DIFF
--- a/qml/Connectors/BluetoothDevice.qml
+++ b/qml/Connectors/BluetoothDevice.qml
@@ -19,7 +19,7 @@
  */
 
 import QtQuick 2.0
-import org.nemomobile.dbus 2.0
+import Nemo.DBus 2.0
 
 Item {
     id: _device

--- a/qml/Connectors/BluetoothService.qml
+++ b/qml/Connectors/BluetoothService.qml
@@ -21,7 +21,7 @@ pragma Singleton
 
 import QtQuick 2.0
 import Connman 0.2
-import org.nemomobile.dbus 2.0
+import Nemo.DBus 2.0
 
 Item {
     id: bluetoothService


### PR DESCRIPTION
Since this was updated in nemo-qml-plugin-dbus.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>