### PR TITLE
Add mainDesktop.qml

### DIFF
--- a/qml/StatusBar/SystemIndicators.qml
+++ b/qml/StatusBar/SystemIndicators.qml
@@ -20,6 +20,7 @@
 
 import QtQuick 2.5
 import LunaNext.Common 0.1
+import LuneOS.Bluetooth 0.1
 import "../Connectors"
 import "Indicators"
 

--- a/qml/luna-next-qml.qmlproject
+++ b/qml/luna-next-qml.qmlproject
@@ -3,7 +3,7 @@
 import QmlProject 1.1
 
 Project {
-    mainFile: "main.qml"
+    mainFile: "mainDesktop.qml"
     
     /* Include .qml, .js, and image files from current directory and subdirectories */
     QmlFiles {

--- a/qml/mainDesktop.qml
+++ b/qml/mainDesktop.qml
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2013 Simon Busch <morphis@gravedo.de>
+ * Copyright (C) 2013 Christophe Chapuis <chris.chapuis@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+import QtQuick 2.6
+import QtQuick.Window 2.2
+
+import LunaNext.Common 0.1
+import LunaNext.Compositor 0.1
+
+// The compositor is exposed by the LunaNext module.
+// It manages the creation/destruction of windows
+// in accordance with the lifecycle of the apps.
+Compositor {
+    id: compositor
+    property QtObject globalCompositor: compositor;
+
+    property Window outputWindow: compositorOutput
+
+    property Window content: Window {
+        id: compositorOutput
+
+        width: Settings.displayWidth
+        height: Settings.displayHeight
+        color: "black"
+        visible: false
+
+        OrientationHelper {
+            id: orientationHelper
+            automaticOrientation: false
+            transitionEnabled: false
+
+            Loader {
+                id: mainShellLoader
+
+                property QtObject compositor: compositor
+                property string cardShellState: mainShellLoader.state
+
+                anchors.fill: parent
+
+                focus: true
+                onSourceChanged: Keys.forwardTo = [ mainShellLoader.item ]
+            }
+
+            BootLoader {
+                shellLoader: mainShellLoader
+
+                anchors.fill: parent
+                z: 1 // above the main shell
+            }
+        }
+    }
+
+    Component.onCompleted: {
+        content.show();
+    }
+}


### PR DESCRIPTION
Since Qt 5.8 it wasn't possible to run this on desktop anymore due to
QtWayland.Compositor import. Created a separate mainDesktop.qml without
this import.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>