### PR TITLE
LaunchBar: fix incorrect parenting (bis)

### DIFF
--- a/qml/LaunchBar/LaunchBar.qml
+++ b/qml/LaunchBar/LaunchBar.qml
@@ -117,7 +117,7 @@ Item {
             Item {
                 id: launcherIconDelegate
 
-                anchors.verticalCenter: launchBarListView.verticalCenter
+                anchors.verticalCenter: parent ? parent.verticalCenter : undefined
                 height: launcherIcon.height
                 width: launcherIcon.width
 


### PR DESCRIPTION
A delegate item might still exist without a parent, as a Qt
optimization to reuse it later on.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>
