### PR TITLE
TelephonyService: subscribe to service as soon as it appears.

### DIFF
--- a/qml/Connectors/TelephonyService.qml
+++ b/qml/Connectors/TelephonyService.qml
@@ -31,41 +31,15 @@ Item {
     property int bars: 0
     property int rssi: 0
 
-    Timer {
-        id: resubscribeTimer
-        interval: 500
-        repeat: false
-        running: false
-        onTriggered: {
-            probeTelephonyService();
-        }
-    }
-
     ServiceStatus {
         serviceName: "com.palm.telephony"
         onConnected: {
             console.log("TelephonyService: service connected");
-            probeTelephonyService();
+            subscribeTelephonyService();
         }
         onDisconnected: {
             console.log("TelephonyService: service disconnected");
         }
-    }
-
-    function handleTelephonyServiceProbeResponse(message) {
-        var response = JSON.parse(message.payload);
-
-        if (!response.returnValue &&
-             response.errorText === "Backend not initialized") {
-            resubscribeTimer.start();
-            return;
-        }
-
-        subscribeTelephonyService();
-    }
-
-    function probeTelephonyService() {
-        powerQuery.call(JSON.stringify({}), handleTelephonyServiceProbeResponse, function (errorMessage) { });
     }
 
     function subscribeTelephonyService() {


### PR DESCRIPTION
**Depends on** https://github.com/webOS-ports/webos-telephonyd/pull/19

With improvement from webos-telephonyd, it is now possible to subscribe
to the services even when the service isn't fully initialized yet.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>