### PR TITLE
default-launcher-page-layout.json: Update appId for Preware

### DIFF
--- a/qml/Tests/default-launcher-page-layout.json
+++ b/qml/Tests/default-launcher-page-layout.json
@@ -21,7 +21,7 @@
     {
         "title" : "downloads",
         "items" : [
-            "org.webosinternals.preware_default"
+            "org.webosports.app.preware_default"
         ] 
     },
     {


### PR DESCRIPTION
After the renaming due to ACG migration.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>