### PR TITLE
LockScreen: Make sure we display it always even in First Use

### DIFF
--- a/qml/LockScreen/LockScreen.qml
+++ b/qml/LockScreen/LockScreen.qml
@@ -23,7 +23,7 @@ import LunaNext.Common 0.1
 Item {
     id: lockScreen
 
-    visible: locked && !isFirstUse
+    visible: locked
 
     property Item windowManagerInstance;
 


### PR DESCRIPTION
LockScreen wouldn't show when we would be in FirstUse and screen would turn off and on before completing First Use. We should display lock screen in such case too, otherwise only solution would be to reboot the phone.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>