### PR TITLE
luna-next-cardshell: Set restoreMode for Bindings

### DIFF
--- a/qml/CardView/SwipeableCard.qml
+++ b/qml/CardView/SwipeableCard.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.0
+import QtQml 2.15
 
 Item {
     id: swipeableRoot
@@ -43,6 +44,7 @@ Item {
             target: flickableArea
             property: "contentY"
             value: 0
+            restoreMode: Binding.RestoreBinding
         }
 
         // handling of card swipe-out, either by drag or by flick

--- a/qml/LaunchBar/FullLauncher.qml
+++ b/qml/LaunchBar/FullLauncher.qml
@@ -19,6 +19,7 @@
 import QtQuick 2.0
 import QtQuick.Controls 1.1
 import QtQuick.Controls.Styles 1.1
+import QtQml 2.15
 import LunaNext.Common 0.1
 import LuneOS.Service 1.0
 import LuneOS.Components 1.0
@@ -528,6 +529,7 @@ Item {
                 property: "contentY"
                 value: flkMouseArea.contentY
                 when: !!tabContentList.currentItem.launcherGridView
+                restoreMode: Binding.RestoreBinding
             }
 
             /* Drag area of the grids */

--- a/qml/Notifications/SwipeableNotification.qml
+++ b/qml/Notifications/SwipeableNotification.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.0
+import QtQml 2.15
 
 Item {
     id: swipeableRoot
@@ -46,6 +47,7 @@ Item {
             target: flickableArea
             property: "contentX"
             value: 0
+            restoreMode: Binding.RestoreBinding
         }
 
         // handling of card swipe-out, either by drag or by flick

--- a/qml/Utils/FlickableHandleArea.qml
+++ b/qml/Utils/FlickableHandleArea.qml
@@ -1,4 +1,5 @@
-import QtQuick 2.0;
+import QtQuick 2.0
+import QtQml 2.15
 
 Item {
     id: flickableHandleArea
@@ -17,6 +18,7 @@ Item {
         property: "contentY"
         value: contentOffset - handleItem.y
         when: !!contentOffset
+        restoreMode: Binding.RestoreBinding
     }
 
     Item {


### PR DESCRIPTION
Solves warnings in Qt 5.15+:

QML Binding: Not restoring previous value because restoreMode has not been set.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>