### PR TITLE
SystemIndicator.qml: Disable the recording indicator

### DIFF
--- a/qml/StatusBar/SystemIndicators.qml
+++ b/qml/StatusBar/SystemIndicators.qml
@@ -50,7 +50,9 @@ Row {
         anchors.top: indicatorsRow.top
         anchors.bottom: indicatorsRow.bottom
 
-        enabled: compositor.recording
+        // FIXME We don't have this yet in luna-surfacemanager it seems. Disable it for now.
+        // enabled: compositor.recording
+        enabled: false
     }
 
     AirplaneModeService {


### PR DESCRIPTION
Seeing we don't have this (yet) in luna-surfacemanager, let's disable it for now.

Solves always visible recording icon and the following in logs:
Apr 30 09:17:18 qemux86-64 surface-manager[581]: [] [pmlog] surface-manager LSM {} (null), file:///usr/lib/qml/WebOSCompositor/qml/StatusBar/SystemIndicators.qml:53:9: Unable to assign [undefined] to bool

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>