### PR TITLE
ApplicationModel.qml: Use luna-appmanager for launchPointChanges

### DIFF
--- a/qml/LunaSysAPI/ApplicationModel.qml
+++ b/qml/LunaSysAPI/ApplicationModel.qml
@@ -99,7 +99,7 @@ ListModel {
             return;
 
         // register handler for possible launch point change events
-        service.subscribe("luna://com.webos.service.applicationManager/launchPointChanges",
+        service.subscribe("luna://com.palm.applicationManager/launchPointChanges",
             JSON.stringify({"subscribe":true}), handleLaunchPointChanges, handleError);
 
         refresh();


### PR DESCRIPTION
Since sam doesn't provide the API for launchPointChanges, use the one from luna-appmanager instead.

Fixes: May 01 21:36:19 qemux86-64 sam[609]: [] [pmlog] <default-lib> LS_NO_METH {"METHOD":"launchPointChanges"} Couldn't find method: launchPointChanges

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>