### PR TITLE
LaunchBar.qml: Update Link for Browser

### DIFF
--- a/qml/LaunchBar/LaunchBar.qml
+++ b/qml/LaunchBar/LaunchBar.qml
@@ -268,7 +268,7 @@ Item {
             //Icons are depending on Settings.tabletUi, which we check and we'll populate the list accordingly
             if(Settings.tabletUi)
             {
-                launcherListModel.model.append({appId: "org.webosports.app.browser",   icon: "/usr/palm/applications/org.webosports.app.browser/icon.png"});
+                launcherListModel.model.append({appId: "com.webos.app.enactbrowser",   icon: "/usr/palm/applications/com.webos.app.enactbrowser/icon.png"});
                 launcherListModel.model.append({appId: "com.palm.app.email",         icon: "/usr/palm/applications/com.palm.app.email/icon.png"});
                 launcherListModel.model.append({appId: "com.palm.app.calendar", icon: "/usr/palm/applications/com.palm.app.calendar/images/launcher/icon-"+Qt.formatDate(new Date, "d")+".png"});
                 launcherListModel.model.append({appId: "org.webosports.app.messaging", icon: "/usr/palm/applications/org.webosports.app.messaging/icon.png"});


### PR DESCRIPTION
Not a big fan of the icon for EnactBrowser, but that could be addressed separately.

Fixes:

Oct 24 12:22:29 qemux86-64 surface-manager[503]: [] [pmlog] surface-manager LSM {} (null), file:///usr/lib/qml/WebOSCompositor/qml/LaunchBar/LaunchableAppIcon.qml:44:9: QML QQuickImage: Cannot open: file:///usr/palm/applications/org.webosports.app.browser/icon.png