### PR TITLE
LaunchableAppIcon.qml: Use default icon in case the one specified can…

### DIFF
--- a/qml/LaunchBar/LaunchableAppIcon.qml
+++ b/qml/LaunchBar/LaunchableAppIcon.qml
@@ -51,7 +51,7 @@ Item {
 
             sourceSize.height: height
             sourceSize.width: width
-            source: launchableAppIcon.appIcon
+            source: FileUtils.exists(launchableAppIcon.appIcon) ? launchableAppIcon.appIcon : Qt.resolvedUrl("../images/default-app-icon.png")
 
             visible: !glow
         }


### PR DESCRIPTION
…not be found

Fixes the apps without icon in the launcher, because sometimes the icon specified in appinfo.json cannot be found.

Line 3977: Oct 24 09:46:10 qemux86-64 surface-manager[614]: [] [pmlog] surface-manager LSM {} (null), file:///usr/lib/qml/WebOSCompositor/qml/LaunchBar/LaunchableAppIcon.qml:44:9: QML QQuickImage: Cannot open: file:///usr/palm/applications/sdl2_opengles1_test/icon.png

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
