### PR TITLE
luna-next-cardshell: Update to accomodate batteryd

### DIFF
--- a/qml/Connectors/BatteryService.qml
+++ b/qml/Connectors/BatteryService.qml
@@ -91,9 +91,9 @@ Item {
             batteryLevel = -1;
         else {
             /* query initial values */
-            lunaService.call("luna://com.palm.power/com/palm/power/chargerStatusQuery",
+            lunaService.call("luna://com.webos.service.battery/com/palm/power/chargerStatusQuery",
                              "{}", handlePowerdUsbDockStatus, handleError);
-            lunaService.call("luna://com.palm.power/com/palm/power/batteryStatusQuery",
+            lunaService.call("luna://com.webos.service.battery/com/palm/power/batteryStatusQuery",
                              "{}", handlePowerdBatteryEvent, handleError);
         }
     }

--- a/qml/StatusBar/SystemMenu/BatteryElement.qml
+++ b/qml/StatusBar/SystemMenu/BatteryElement.qml
@@ -59,7 +59,7 @@ MenuListEntry {
             service.subscribe("luna://com.palm.bus/signal/addmatch",
                                   JSON.stringify({"category":"/com/palm/power","method":"batteryStatus"}),
                                   updateBatteryStatus, handleError);
-            service.call("luna://com.palm.power/com/palm/power/batteryStatusQuery",
+            service.call("luna://com.webos.service.battery/com/palm/power/batteryStatusQuery",
                               "{}",
                               updateBatteryStatus,
                               handleError);


### PR DESCRIPTION
Since we dropped powerd in favour of batteryd, need to update the calls accordingly.