### PR TITLE
luna-next-cardshell: Update API calls

### DIFF
--- a/qml/Connectors/BatteryService.qml
+++ b/qml/Connectors/BatteryService.qml
@@ -30,7 +30,7 @@ Item {
     property int percentage: 0
     property bool charging: false
 
-    property bool powerdAvailable: false
+    property bool batterydAvailable: false
 
     property bool _playSoundWhenCharged: false
 
@@ -68,8 +68,8 @@ Item {
 
         onInitialized: {
             lunaService.subscribe("luna://com.palm.bus/signal/registerServerStatus",
-                                  "{\"serviceName\":\"com.palm.power\"}",
-                                  handlePowerdServiceStatus, handleError);
+                                  "{\"serviceName\":\"com.webos.service.battery\"}",
+                                  handleBatterydServiceStatus, handleError);
             lunaService.subscribe("luna://com.palm.bus/signal/addmatch",
                                   "{\"category\":\"/com/palm/power\",\"method\":\"batteryStatus\"}",
                                   handlePowerdBatteryEvent, handleError);
@@ -83,11 +83,11 @@ Item {
         console.log("Service error: " + message);
     }
 
-    function handlePowerdServiceStatus(message) {
+    function handleBatterydServiceStatus(message) {
         var response = JSON.parse(message.payload);
 
-        powerdAvailable = response.connected;
-        if (!powerdAvailable)
+        batterydAvailable = response.connected;
+        if (!batterydAvailable)
             batteryLevel = -1;
         else {
             /* query initial values */

--- a/qml/Notifications/PowerMenu.qml
+++ b/qml/Notifications/PowerMenu.qml
@@ -73,7 +73,7 @@ Item {
                 root.visible = false;
                 console.log("Reboot requested !")
                 shutdownSound.play();
-                powerKeyService.call("luna://com.palm.power/shutdown/machineReboot",
+                powerKeyService.call("luna://com.webos.service.sleep/shutdown/machineReboot",
                     JSON.stringify({"reason": "User requested reboot"}), undefined, onRebootActionError)
             }
 
@@ -115,7 +115,7 @@ Item {
                 root.visible = false;
                 console.log("Shutdown requested !")
                 shutdownSound.play();
-                powerKeyService.call("luna://com.palm.power/shutdown/machineOff",
+                powerKeyService.call("luna://com.webos.service.sleep/shutdown/machineOff",
                     JSON.stringify({"reason": "User requested poweroff"}), undefined, onPowerOffActionError)
             }
 


### PR DESCRIPTION
Since the deprecation of powerd, these calls are now provided by com.webos.service.sleep instead. Old calls still work, but better to update.

For batteryd: Update calls as well to reflect new structure with sleepd, com.webos.service.power2 and com.webos.service.battery