### PR TITLE
TelephonyService: remove MeeGo prefix

### DIFF
--- a/qml/Connectors/TelephonyService.qml
+++ b/qml/Connectors/TelephonyService.qml
@@ -19,7 +19,7 @@
 import QtQuick 2.0
 import LuneOS.Service 1.0
 import LunaNext.Common 0.1
-import MeeGo.QOfono 0.2
+import QOfono 0.2
 import Connman 0.2
 
 Item {


### PR DESCRIPTION
Following the change in libqofono:
https://github.com/sailfishos/libqofono/commit/d60174d3508a73f4a6e28eeaf599f19b61a54355

the MeeGo prefix is now removed.