### PR TITLE
Notifications: retract the banner when its toast is withdrawn

### DIFF
--- a/qml/Notifications/NotificationArea.qml
+++ b/qml/Notifications/NotificationArea.qml
@@ -53,6 +53,15 @@ Rectangle {
         onAddBannerNotification: (notifObject) => {
            bannerItemsPopups.popupModel.append({"object": notifObject});
         }
+
+        onRemoveBannerNotification: (notifObject) => {
+           let toastId = mergedModel.getToastIdFromNotif(notifObject);
+           for (var i = bannerItemsPopups.popupModel.count - 1; i >= 0; i--) {
+               let entry = bannerItemsPopups.popupModel.get(i).object;
+               if (entry && mergedModel.getToastIdFromNotif(entry) === toastId)
+                   bannerItemsPopups.popupModel.remove(i);
+           }
+        }
     }
 
     // Minimized view

--- a/qml/Notifications/NotificationAreaTablet.qml
+++ b/qml/Notifications/NotificationAreaTablet.qml
@@ -56,6 +56,15 @@ Rectangle {
         onAddBannerNotification: (notifObject) => {
            bannerItemsPopups.popupModel.append({"object": notifObject});
         }
+
+        onRemoveBannerNotification: (notifObject) => {
+           let toastId = mergedModel.getToastIdFromNotif(notifObject);
+           for (var i = bannerItemsPopups.popupModel.count - 1; i >= 0; i--) {
+               let entry = bannerItemsPopups.popupModel.get(i).object;
+               if (entry && mergedModel.getToastIdFromNotif(entry) === toastId)
+                   bannerItemsPopups.popupModel.remove(i);
+           }
+        }
     }
 
     Item {

--- a/qml/Notifications/NotificationsMergedModel.qml
+++ b/qml/Notifications/NotificationsMergedModel.qml
@@ -31,6 +31,7 @@ ListModel {
     dynamicRoles: true
 
     signal addBannerNotification(var notif);
+    signal removeBannerNotification(var notif);
 
     function getToastIdFromNotif(notifObject) {
         return notifObject.sourceId+"-"+notifObject.timestamp;
@@ -63,6 +64,12 @@ ListModel {
         function onRowsAboutToBeRemoved(index, first, last) {
             let notifObject = notificationService.toastModel.get(last);
             let toastId = getToastIdFromNotif(notifObject);
+
+            // The banner popup is a separate model, so removing the sticky
+            // entry below is not enough: a banner still on screen when its
+            // toast is withdrawn would sit there until its own timer expired.
+            removeBannerNotification(notifObject);
+
             for( var i=0; i<mergedModel.count; ++i ) {
                 if( mergedModel.get(i).notifObject &&
                     getToastIdFromNotif(mergedModel.get(i).notifObject) === toastId ) {


### PR DESCRIPTION
An application that posts a banner and later withdraws it could not make it go away. Three components were involved and each was missing a link; notificationmgr now posts a toastAction when a toast is closed, and luna-surfacemanager-base's toast model acts on it by removing the row. This is the last piece.

The sticky notification was already handled: onRowsAboutToBeRemoved drops the matching entry from the merged model. The banner popup is a separate model though, appended to on addBannerNotification and otherwise only emptied by its own timer, so a banner still on screen when its toast was withdrawn would sit there until it expired on its own.

Emit removeBannerNotification alongside, and have both notification areas drop the matching popup entries. Matching is on getToastIdFromNotif(), the same sourceId-timestamp pair the merged model already keys on. The loop runs backwards so the indices stay valid while removing.